### PR TITLE
Finish game creation and first turn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ click==7.1.2
 pydantic==1.8.1
 typing-extensions==3.7.4.3
 websockets==8.1
+edagames-grpc==0.3.4

--- a/server/game.py
+++ b/server/game.py
@@ -17,6 +17,7 @@ class Game:
         self.uuid_game = str(uuid.uuid4())
         self.state = 'pending'
         self.challenge_id = challenge_id
+        self.external_game_id = None
 
     def next_turn(self):
         # Start timeout timer

--- a/server/game.py
+++ b/server/game.py
@@ -17,3 +17,9 @@ class Game:
         self.uuid_game = str(uuid.uuid4())
         self.state = 'pending'
         self.challenge_id = challenge_id
+
+    def next_turn(self):
+        # Start timeout timer
+        # Build turn_token
+        # Return dict with turn_token
+        return {'turn_token': '0000001'}

--- a/server/grpc_adapter.py
+++ b/server/grpc_adapter.py
@@ -1,20 +1,9 @@
-# from eda5grpc.client import Client
+from edagames_grpc.client import ClientGRPC
 
 from server.environment import FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT
 
 
 cached_adapters = {}
-
-
-class Client:
-    def __init__(self, *args):
-        pass
-
-    async def create_game(self, players):
-        return 'test-00000001'
-
-    async def execute_action(self, id, data_dict):
-        return {'idgame': '123e4567-e89b-12d3-a456-426614174000', 'data': {}}
 
 
 def discover_game(game_name: str):
@@ -28,6 +17,6 @@ class GRPCAdapterFactory:
             adapter = cached_adapters[game_name]
         except KeyError:
             # Service discovery goes here (?
-            adapter = Client(discover_game(game_name))
+            adapter = ClientGRPC(discover_game(game_name))
             cached_adapters[game_name] = adapter
         return adapter

--- a/server/grpc_adapter.py
+++ b/server/grpc_adapter.py
@@ -1,4 +1,4 @@
-# from edagames_grpc.client import Client
+# from eda5grpc.client import Client
 
 from server.environment import FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT
 

--- a/server/server_event.py
+++ b/server/server_event.py
@@ -37,7 +37,7 @@ class AcceptChallenge(ServerEvent):
         game_start_state = await adapter.create_game(game.players)
         game.external_game_id = game_start_state.id_game
         extra_turn_data = game.next_turn()
-        notify_your_turn(
+        await notify_your_turn(
             game_start_state.current_player,
             game_start_state.turn_data.update(extra_turn_data),
         )

--- a/server/server_event.py
+++ b/server/server_event.py
@@ -34,7 +34,13 @@ class AcceptChallenge(ServerEvent):
     async def start_game(self, game: Game):
         game.state = 'accepted'
         adapter = await GRPCAdapterFactory.get_adapter(game.name)
-        await adapter.create_game(game.players)
+        game_start_state = await adapter.create_game(game.players)
+        game.external_game_id = game_start_state.id_game
+        extra_turn_data = game.next_turn()
+        notify_your_turn(
+            game_start_state.current_player,
+            game_start_state.turn_data.update(extra_turn_data),
+        )
 
 
 class Movements(ServerEvent):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -15,3 +15,9 @@ class TestGame(unittest.TestCase):
         game = Game([user, challenged_player], challenge_id)
         self.assertIn(user, game.players)
         self.assertIn(challenged_player, game.players)
+
+    def test_next_turn(self):
+        game = Game(['p1', 'p2'], 123)
+        turn_token = {'turn_token': '0000001'}
+        token = game.next_turn()
+        self.assertEqual(token, turn_token)

--- a/tests/test_grpc_adapter.py
+++ b/tests/test_grpc_adapter.py
@@ -1,13 +1,13 @@
 import unittest
 from unittest.mock import patch
 
-from server.grpc_adapter import GRPCAdapterFactory, Client, cached_adapters
+from server.grpc_adapter import GRPCAdapterFactory, ClientGRPC, cached_adapters
 
 
 class TestGRPCAdapterFactory(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_adapter_cached(self):
-        adapter_mock = Client('test:1234')
+        adapter_mock = ClientGRPC('test:1234')
         cached_adapters.update({'cached': adapter_mock})
         adapter = await GRPCAdapterFactory.get_adapter('cached')
         self.assertEqual(adapter, adapter_mock)


### PR DESCRIPTION
- Replace mock adapter with edagames-grpc lib
- Add hooks for turn token creation and timeout set/reset in start_game
- Add method in game to generate turn token and (maybe) set timeout
- Add external game_id to game
- Finish game creation and send first your_turn
- Fix test error (AsyncMock not awaited, switched for MagicMock)