### PR TITLE
[MINOR] EDA-1338: Connection manager refactor

### DIFF
--- a/server/connection_manager.py
+++ b/server/connection_manager.py
@@ -30,9 +30,12 @@ class ConnectionManager:
         await self.notify_user_list_changed()
         return client
 
-    async def broadcast(self, data: Dict):
-        for connection in self.connections.values():
-            await connection.send_text(json.dumps(data))
+    async def broadcast(self, event: str, data: Dict):
+        for client_websocket in self.connections.values():
+            await client_websocket.send_text(json.dumps({
+                'event': event,
+                'data': data,
+            }))
 
     async def send(self, client: str, event: str, data: Dict):
         client_websocket = self.connections.get(client)
@@ -51,14 +54,13 @@ class ConnectionManager:
             logger.info('[Websocket]exception {}'.format(e))
 
     async def notify_user_list_changed(self):
-        data = {
-            'event': websocket_events.EVENT_LIST_USERS,
-            'data': {
+        logger.info('[Websocket]Users {}'.format(list(self.connections.keys())))
+        await self.broadcast(
+            websocket_events.EVENT_LIST_USERS,
+            {
                 'users': list(self.connections.keys()),
             },
-        }
-        logger.info('[Websocket]Users {}'.format(list(self.connections.keys())))
-        await self.broadcast(data)
+        )
 
 
 manager = ConnectionManager()

--- a/server/connection_manager.py
+++ b/server/connection_manager.py
@@ -37,7 +37,7 @@ class ConnectionManager:
                 'data': data,
             }))
 
-    async def send(self, client: str, event: str, data: Dict):
+    async def send_client(self, client: str, event: str, data: Dict):
         client_websocket = self.connections.get(client)
         logger.info('[Websocket]Send: Client : {} Event:{} ,data :{}'.format(client, event, data))
         if client_websocket is not None:

--- a/server/connection_manager.py
+++ b/server/connection_manager.py
@@ -36,20 +36,20 @@ class ConnectionManager:
 
     async def bulk_send(self, clients: List[str], event: str, data: Dict):
         for client in clients:
-            asyncio.create_task(self.send(
+            asyncio.create_task(self._send(
                 self.connections.get(client),
                 event,
                 data,
             ))
 
-    async def send_client(self, client: str, event: str, data: Dict):
-        await self.send(
+    async def send(self, client: str, event: str, data: Dict):
+        await self._send(
             self.connections.get(client),
             event,
             data,
         )
 
-    async def send(self, client_ws: WebSocket, event: str, data: Dict):
+    async def _send(self, client_ws: WebSocket, event: str, data: Dict):
         logger.info(f'[Websocket] Send: Event: {event}, data: {data}')
         try:
             await client_ws.send_text(json.dumps({

--- a/server/connection_manager.py
+++ b/server/connection_manager.py
@@ -32,12 +32,7 @@ class ConnectionManager:
         return client
 
     async def broadcast(self, event: str, data: Dict):
-        for client_websocket in self.connections.values():
-            asyncio.create_task(self.send(
-                client_websocket,
-                event,
-                data,
-            ))
+        await self.bulk_send(self.connections.keys(), event, data)
 
     async def bulk_send(self, clients: List[str], event: str, data: Dict):
         for client in clients:

--- a/server/websockets.py
+++ b/server/websockets.py
@@ -8,7 +8,7 @@ async def notify_challenge_to_client(
     opponent: str,
     challenge_id: str,
 ):
-    await manager.send_client(
+    await manager.send(
         client,
         websocket_events.EVENT_SEND_CHALLENGE,
         {
@@ -19,7 +19,7 @@ async def notify_challenge_to_client(
 
 
 async def notify_error_to_client(client: str, error: str):
-    await manager.send_client(
+    await manager.send(
         client,
         websocket_events.EVENT_SEND_ERROR,
         {
@@ -29,7 +29,7 @@ async def notify_error_to_client(client: str, error: str):
 
 
 async def notify_your_turn(client: str, data: Dict):
-    await manager.send_client(
+    await manager.send(
         client,
         websocket_events.EVENT_SEND_YOUR_TURN,
         data,
@@ -37,7 +37,7 @@ async def notify_your_turn(client: str, data: Dict):
 
 
 async def notify_user_list_to_client(client: str, users: List[str]):
-    await manager.send_client(
+    await manager.send(
         client,
         websocket_events.EVENT_LIST_USERS,
         {

--- a/server/websockets.py
+++ b/server/websockets.py
@@ -8,7 +8,7 @@ async def notify_challenge_to_client(
     opponent: str,
     challenge_id: str,
 ):
-    await manager.send(
+    await manager.send_client(
         client,
         websocket_events.EVENT_SEND_CHALLENGE,
         {
@@ -19,7 +19,7 @@ async def notify_challenge_to_client(
 
 
 async def notify_error_to_client(client: str, error: str):
-    await manager.send(
+    await manager.send_client(
         client,
         websocket_events.EVENT_SEND_ERROR,
         {
@@ -29,7 +29,7 @@ async def notify_error_to_client(client: str, error: str):
 
 
 async def notify_your_turn(client: str, data: Dict):
-    await manager.send(
+    await manager.send_client(
         client,
         websocket_events.EVENT_SEND_YOUR_TURN,
         data,
@@ -37,7 +37,7 @@ async def notify_your_turn(client: str, data: Dict):
 
 
 async def notify_user_list_to_client(client: str, users: List[str]):
-    await manager.send(
+    await manager.send_client(
         client,
         websocket_events.EVENT_LIST_USERS,
         {

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -17,7 +17,19 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoiVGVzdCBDbGllbnQgMSJ9'
             '.zrXQiT77v9jnUVsZHr41HAZVDnJtRa84t8hmRVdzPck',
             'Test Client 1',
-        )
+        ),
+        (
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+            'eyJ1c2VyIjoiUGVkcm8ifQ.'
+            'h85yCXGm1BdXbKKnLgOJ52vHAdGmcUpJ5gfCgjYyAJQ',
+            'Pedro',
+        ),
+        (
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+            'eyJ1c2VyIjoiUGFibG8ifQ.'
+            '3qIB7M-S34ALo1XQQ-7V4Zvzou3SPL5lJsWbINHOFBc',
+            'Pablo',
+        ),
     ])
     async def test_connect_valid(self, token, expected):
         websocket = AsyncMock()
@@ -31,19 +43,26 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
 
     @parameterized.expand([
         (
-            '/?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
             'eyJ1c2VyIjoiVXNlciBUZXN0NCJ9.'
-            'p6MnNJLD5jwTH1C0PvqUb-spfc7XW7xf6gQjSiDrktg&action=NULL&msg=NULL',
-            'Test Client 1',
-        )
+            'p6MnNJLD5jwTH1C0PvqUb-spfc7XW7xf6gQjSiDrktg',
+        ),
+        (
+            'eyJhbGciOiJIUzsInR5cCI6IkpXVCJ9.'
+            'eyJ1c2VyIjoiciBUZXN0NCJ9.'
+            'p6MnNJLD5jwTH1C0PvqUb-sp',
+        ),
+        (
+            '',
+        ),
     ])
-    async def test_connect_invalid(self, token, expected):
+    async def test_connect_invalid(self, token):
         websocket = AsyncMock()
         notify_patched = AsyncMock()
         self.manager.notify_user_list_changed = notify_patched
         with patch('server.connection_manager.JWT_TOKEN_KEY', 'EDAGame$!2021'):
             await self.manager.connect(websocket, token)
-        self.assertNotIn(expected, self.manager.connections)
+        self.assertEqual({}, self.manager.connections)
         websocket.close.assert_called()
         notify_patched.assert_not_called()
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -98,7 +98,7 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
         await self.manager.broadcast(event, data)
         connection.send_text.assert_called_with(expected)
 
-    async def test_manager_send(self):
+    async def test_manager_send_client(self):
         user = 'User'
         event = 'event'
         data = {
@@ -112,7 +112,7 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             user: websocket_patched,
         }
 
-        await self.manager.send(
+        await self.manager.send_client(
             user,
             event,
             data,

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -75,16 +75,27 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
 
     @parameterized.expand([
         (
+            'some_event',
             {'data': 'Test Message 1'},
-            '{"data": "Test Message 1"}',
+            '{"event": "some_event", "data": {"data": "Test Message 1"}}',
+        ),
+        (
+            'empty',
+            {},
+            '{"event": "empty", "data": {}}',
+        ),
+        (
+            '',
+            '',
+            '{"event": "", "data": ""}',
         ),
     ])
-    async def test_broadcast(self, data, expected):
+    async def test_broadcast(self, event, data, expected):
         connection = MagicMock()
         connection.send_text = AsyncMock()
         self.manager.connections = {'Test Client 1': connection}
 
-        await self.manager.broadcast(data)
+        await self.manager.broadcast(event, data)
         connection.send_text.assert_called_with(expected)
 
     async def test_manager_send(self):
@@ -122,9 +133,9 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             'client 3': 'websocket',
         }
         await self.manager.notify_user_list_changed()
-        broadcast_patched.assert_called_with({
-            'event': websocket_events.EVENT_LIST_USERS,
-            'data': {
+        broadcast_patched.assert_called_with(
+            websocket_events.EVENT_LIST_USERS,
+            {
                 'users': ['client 1', 'client 2', 'client 3'],
             },
-        })
+        )

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -75,16 +75,17 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
 
     @parameterized.expand([
         (
-            'Test Message 1',
-        )
+            {'data': 'Test Message 1'},
+            '{"data": "Test Message 1"}',
+        ),
     ])
-    async def test_broadcast(self, data):
+    async def test_broadcast(self, data, expected):
         connection = MagicMock()
         connection.send_text = AsyncMock()
         self.manager.connections = {'Test Client 1': connection}
 
         await self.manager.broadcast(data)
-        connection.send_text.assert_called()
+        connection.send_text.assert_called_with(expected)
 
     async def test_manager_send(self):
         user = 'User'

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -101,8 +101,8 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             data,
         )
 
-    @patch.object(ConnectionManager, 'send')
-    async def test_manager_send_client(self, send_patched):
+    @patch.object(ConnectionManager, '_send')
+    async def test_manager_send(self, send_patched):
         user = 'User'
         event = 'event'
         data = {
@@ -110,7 +110,7 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             'other_data': 'some other data',
         }
         self.manager.connections = {user: 'user_websocket'}
-        await self.manager.send_client(user, event, data)
+        await self.manager.send(user, event, data)
         send_patched.assert_called_with(
             'user_websocket',
             event,
@@ -130,8 +130,9 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
         event = 'event'
         data = {'data': "Test Message 1"}
         with patch('asyncio.create_task') as create_task_patched,\
-                patch.object(ConnectionManager, 'send', new_callable=MagicMock) as send_patched:
+                patch.object(ConnectionManager, '_send', new_callable=MagicMock) as send_patched:
             await self.manager.bulk_send(clients, event, data)
+        await self.manager.bulk_send(clients, event, data)
         self.assertEqual(len(create_task_patched.mock_calls), len(clients))
         send_patched.assert_has_calls(
             [call(ws, event, data) for ws in connections.values()]
@@ -143,7 +144,7 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
     #         user: websocket_patched,
     #     }
 
-    #     await self.manager.send_client(
+    #     await self.manager.send(
     #         user,
     #         event,
     #         data,

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -138,24 +138,41 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
             [call(ws, event, data) for ws in connections.values()]
         )
 
-    # async def test_manager_send(self):
-    #     websocket_patched = AsyncMock()
-    #     self.manager.connections = {
-    #         user: websocket_patched,
-    #     }
-
-    #     await self.manager.send(
-    #         user,
-    #         event,
-    #         data,
-    #     )
-
-    #     websocket_patched.send_text.assert_called_with(
-    #         json.dumps({
-    #             'event': event,
-    #             'data': data
-    #         })
-    #     )
+    @parameterized.expand([
+        (
+            'event',
+            {'field': 'Test Message 1'},
+            '{"event": "event", "data": {"field": "Test Message 1"}}',
+        ),
+        (
+            'event',
+            {'field': 'Test Message 1', 'field2': 'Other message'},
+            '{"event": "event", "data": {"field": "Test Message 1", "field2": "Other message"}}',
+        ),
+        (
+            '',
+            {'field': 'Test Message 1'},
+            '{"event": "", "data": {"field": "Test Message 1"}}',
+        ),
+        (
+            'event',
+            {},
+            '{"event": "event", "data": {}}',
+        ),
+        (
+            '',
+            {},
+            '{"event": "", "data": {}}',
+        ),
+    ])
+    async def test_manager_send_internal(self, event, data, expected):
+        websocket_patched = AsyncMock()
+        await self.manager._send(
+            websocket_patched,
+            event,
+            data,
+        )
+        websocket_patched.send_text.assert_called_with(expected)
 
     @patch.object(ConnectionManager, 'broadcast')
     async def test_notify_user_list_changed(self, broadcast_patched):

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -90,11 +90,6 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
         ),
     ])
     async def test_broadcast(self, connections):
-        connections = {
-            'Test Client 1': 'websocket1',
-            'Test Client 2': 'websocket2',
-            'Test Client 3': 'websocket3',
-        }
         event = 'event'
         data = {'data': "Test Message 1"}
         self.manager.connections = connections

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -42,16 +42,19 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
 
     @parameterized.expand([
         (
+            # Invalid signature
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
             'eyJ1c2VyIjoiVXNlciBUZXN0NCJ9.'
             'p6MnNJLD5jwTH1C0PvqUb-spfc7XW7xf6gQjSiDrktg',
         ),
         (
+            # Malformed token
             'eyJhbGciOiJIUzsInR5cCI6IkpXVCJ9.'
             'eyJ1c2VyIjoiciBUZXN0NCJ9.'
             'p6MnNJLD5jwTH1C0PvqUb-sp',
         ),
         (
+            # Empty token
             '',
         ),
     ])

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -14,7 +14,7 @@ import server.constants as websocket_events
 
 
 class TestWebsockets(unittest.IsolatedAsyncioTestCase):
-    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
     async def test_notify_error_to_client(self, send_patched):
         client = 'User 1'
         error = 'message error'
@@ -30,7 +30,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
     async def test_notify_challenge_to_client(self, send_patched):
         challenge_sender = 'User 1'
         challenge_receiver = 'User 2'
@@ -49,7 +49,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
     async def test_notify_your_turn(self, send_patched):
         challenge_sender = 'User 1'
         data = {"game_id": "c303282d-f2e6-46ca-a04a-35d3d873712d"}
@@ -63,7 +63,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             data
         )
 
-    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
     async def test_notify_user_list_to_client(self, send_patched):
         client = 'User 1'
         users = ['User 1', 'User 2', 'User 3']

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -14,8 +14,7 @@ import server.constants as websocket_events
 
 
 class TestWebsockets(unittest.IsolatedAsyncioTestCase):
-
-    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
     async def test_notify_error_to_client(self, send_patched):
         client = 'User 1'
         error = 'message error'
@@ -31,7 +30,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
     async def test_notify_challenge_to_client(self, send_patched):
         challenge_sender = 'User 1'
         challenge_receiver = 'User 2'
@@ -50,7 +49,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
     async def test_notify_your_turn(self, send_patched):
         challenge_sender = 'User 1'
         data = {"game_id": "c303282d-f2e6-46ca-a04a-35d3d873712d"}
@@ -64,7 +63,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             data
         )
 
-    @patch.object(ConnectionManager, 'send', new_callable=AsyncMock)
+    @patch.object(ConnectionManager, 'send_client', new_callable=AsyncMock)
     async def test_notify_user_list_to_client(self, send_patched):
         client = 'User 1'
         users = ['User 1', 'User 2', 'User 3']


### PR DESCRIPTION
- Test other cases for invalid connections (invalid/wrong/empty token)
- Improve send method tests, check all calls parameters instead of only testing it's being called
- Refactor send methods
  - 'send' -> 'send_client': sends message to client by name
  - 'send': internal, sends message to websocket
  - 'broadcast': sends message to all connected clients, uses bulk_send
  - 'bulk_send' sends message to list of clients, spawns tasks