### PR TITLE
[MAJOR] EDA-1418: Add tournament id to challenge

### DIFF
--- a/server/game.py
+++ b/server/game.py
@@ -4,7 +4,7 @@ from typing import List
 
 from server.redis import save_string
 
-from server.constants import DEFAULT_GAME, PREFIX_TURN_TOKEN
+from server.constants import PREFIX_TURN_TOKEN
 
 
 def identifier():
@@ -19,9 +19,18 @@ def next_turn(game_id):
 
 def data_challenge(
     players: List[str],
-    name: str = DEFAULT_GAME,
+    tournament_id: str,
+    name: str,
 ):
-    return json.dumps({
-        'players': players,
-        'game': name,
-    })
+    if tournament_id:
+        data = {
+            'players': players,
+            'tournament_id': tournament_id,
+            'game': name,
+        }
+    else:
+        data = {
+            'players': players,
+            'game': name,
+        }
+    return json.dumps(data)

--- a/server/models.py
+++ b/server/models.py
@@ -1,7 +1,9 @@
+from server.constants import DEFAULT_GAME
 from pydantic import BaseModel
 
 
 class Challenge(BaseModel):
     challenger: str
     challenged: str
-    challenge_id: str  # this should be changed for game_name
+    tournament_id: str = None
+    game_name: str = DEFAULT_GAME

--- a/server/router.py
+++ b/server/router.py
@@ -13,8 +13,23 @@ router = APIRouter()
 
 @router.post("/challenge")
 async def challenge(challenge: Challenge):
-    await make_challenge([challenge.challenger, challenge.challenged])
-    return challenge
+    try:
+        await make_challenge(
+            challenge.challenger,
+            challenge.challenged,
+            challenge.tournament_id,
+            challenge.game_name
+        )
+        return challenge
+    except Exception as e:
+        message = f'Unhandled exception ocurred: {e}'
+        status = 500
+
+    return JSONResponse({
+        'status': 'ERROR',
+        'code': status,
+        'message': message,
+    }, status_code=status)
 
 
 @router.get("/users")

--- a/server/utilities_server_event.py
+++ b/server/utilities_server_event.py
@@ -14,7 +14,6 @@ from server.web_requests import notify_end_game_to_web
 
 from server.constants import (
     TIME_SLEEP,
-    DEFAULT_GAME,
     TURN_TOKEN,
     GAME_ID,
     DATA,
@@ -24,11 +23,12 @@ from server.constants import (
 )
 
 
-async def make_challenge(players, game_name=DEFAULT_GAME):
+async def make_challenge(challenger, challenged, tournament_id, game_name):
     challenge_id = identifier()
+    players = [challenger, challenged]
     redis_save(
         challenge_id,
-        data_challenge(players, game_name),
+        data_challenge(players, tournament_id, game_name),
         CHALLENGE_ID,
     )
     await notify_challenge_to_client(

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+from parameterized.parameterized import parameterized
+
 from server.game import data_challenge, identifier, next_turn
 from server.constants import (
     DEFAULT_GAME,
@@ -28,8 +30,13 @@ class TestGame(unittest.TestCase):
             )
             self.assertEqual(turn_token, res)
 
-    def test_data_challenge(self):
-        players = ['Pedro', 'Pablo']
-        expected = f'''{{"players": ["Pedro", "Pablo"], "game": "{DEFAULT_GAME}"}}'''
-        res = data_challenge(players)
+    @parameterized.expand([
+        (
+            ['Pedro', 'Pablo'],
+            '0000-0001',
+            f'{{"players": ["Pedro", "Pablo"], "tournament_id": "0000-0001", "game": "{DEFAULT_GAME}"}}'
+        ),
+    ])
+    def test_data_challenge(self, players, tournament_id, expected):
+        res = data_challenge(players, tournament_id, DEFAULT_GAME)
         self.assertEqual(res, expected)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -36,6 +36,11 @@ class TestGame(unittest.TestCase):
             '0000-0001',
             f'{{"players": ["Pedro", "Pablo"], "tournament_id": "0000-0001", "game": "{DEFAULT_GAME}"}}'
         ),
+        (
+            ['Pedro', 'Pablo'],
+            None,
+            f'{{"players": ["Pedro", "Pablo"], "game": "{DEFAULT_GAME}"}}'
+        ),
     ])
     def test_data_challenge(self, players, tournament_id, expected):
         res = data_challenge(players, tournament_id, DEFAULT_GAME)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5,21 +5,55 @@ from httpx import AsyncClient
 
 from server.server import app, manager
 
+from server.constants import DEFAULT_GAME
+
 
 class TestRouter(unittest.IsolatedAsyncioTestCase):
     @parameterized.expand([
-        ({"challenger": "Ana", "challenged": "Pepe", "challenge_id": "2138123721"}, 200),
+        (
+            "Ana",
+            "Pepe",
+            "2138123721",
+            200,
+        ),
+        (
+            "Ana",
+            "Pepe",
+            None,
+            200,
+        ),
     ])
-    async def test_challenge(self, data, status):
+    async def test_challenge(self, challenger, challenged, tournament_id, status):
+        data = {
+            "challenger": challenger,
+            "challenged": challenged,
+            "tournament_id": tournament_id,
+        }
+        expected = {**data, 'game_name': DEFAULT_GAME}
         with patch('server.router.make_challenge') as mock_make_challenge:
             async with AsyncClient(app=app, base_url="http://test") as ac:
                 response = await ac.post(
                     "/challenge",
                     json=data
                 )
-        mock_make_challenge.assert_awaited_once_with(['Ana', 'Pepe'])
+        mock_make_challenge.assert_awaited_once_with(challenger, challenged, tournament_id, DEFAULT_GAME)
         self.assertEqual(response.status_code, status)
-        self.assertEqual(response.json(), data)
+        self.assertEqual(response.json(), expected)
+
+    async def test_challenge_error(self):
+        data = {
+            "challenger": 'challenger',
+            "challenged": 'challenged',
+            "tournament_id": 'tournament_id',
+        }
+        with patch('server.router.make_challenge') as mock_make_challenge:
+            mock_make_challenge.side_effect = Exception()
+            async with AsyncClient(app=app, base_url="http://test") as ac:
+                response = await ac.post(
+                    "/challenge",
+                    json=data
+                )
+        self.assertEqual(response.status_code, 500)
 
     async def test_update_users_in_django(self):
         user_list = {"users": ["User 1"]}

--- a/tests/test_utilities_server_event.py
+++ b/tests/test_utilities_server_event.py
@@ -27,15 +27,16 @@ class TestMakeFunctions(unittest.IsolatedAsyncioTestCase):
     @patch('server.utilities_server_event.redis_save')
     async def test_make_challenge(self, mock_save, mock_notify):
         challenge_id = 'test_challenge_id'
+        tournament_id = 'test_tournament_id'
         challenger = 'Pedro'
         challenged = 'Pablo'
         players = [challenger, challenged]
         data_challenge = 'test_data_challenge'
         with patch('server.utilities_server_event.identifier', return_value=challenge_id) as mock_identifier:
             with patch('server.utilities_server_event.data_challenge', return_value=data_challenge) as mock_data:
-                await make_challenge(players)
+                await make_challenge(challenger, challenged, tournament_id, DEFAULT_GAME)
                 mock_identifier.assert_called_once_with()
-                mock_data.assert_called_once_with(players, DEFAULT_GAME)
+                mock_data.assert_called_once_with(players, tournament_id, DEFAULT_GAME)
                 mock_save.assert_called_once_with(
                     challenge_id,
                     data_challenge,


### PR DESCRIPTION
- Removes unused (but required) challenge_id parameter from /challenge endpoint
- Adds (optional) tournament_id parameter to /challenge endpoint