### PR TITLE
[MINOR] EDA-1389: Implement queue manager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ typing-extensions==3.7.4.3
 websockets==8.1
 edagames-grpc==1.1.0
 redis==3.5.3
+pika==1.2.0

--- a/run.py
+++ b/run.py
@@ -1,6 +1,13 @@
 import uvicorn
 from server.server import app
+from server.connection_manager import ConnectionManager
+from server.queues import QueueManager
 
 
 if __name__ == '__main__':
+    connection_manager = ConnectionManager()
+    queue_manager = QueueManager()
+    connection_manager.set_queue_manager(queue_manager)
+    queue_manager.set_message_receiver(connection_manager)
+
     uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/server/connection_manager.py
+++ b/server/connection_manager.py
@@ -48,18 +48,24 @@ class ConnectionManager:
 
     async def bulk_send(self, clients: List[str], event: str, data: Dict):
         for client in clients:
-            asyncio.create_task(self._send(
-                self.connections.get(client),
-                event,
-                data,
-            ))
+            try:
+                asyncio.create_task(self._send(
+                    self.connections[client],
+                    event,
+                    data,
+                ))
+            except KeyError:
+                self.queue_manager.send(client, event, data)
 
     async def send(self, client: str, event: str, data: Dict):
-        await self._send(
-            self.connections.get(client),
-            event,
-            data,
-        )
+        try:
+            await self._send(
+                self.connections[client],
+                event,
+                data,
+            )
+        except KeyError:
+            self.queue_manager.send(client, event, data)
 
     async def _send(self, client_ws: WebSocket, event: str, data: Dict):
         logger.info(f'[Websocket] Send: Event: {event}, data: {data}')

--- a/server/constants.py
+++ b/server/constants.py
@@ -62,3 +62,6 @@ MSG_GAME_ID = 'Invalid game id: '
 
 # Log constants
 LOG_PAGE_SIZE = 20
+
+# Rabbit constants
+RABBIT_CLIENT_EXCHANGE = 'client_messages'

--- a/server/constants.py
+++ b/server/constants.py
@@ -65,3 +65,4 @@ LOG_PAGE_SIZE = 20
 
 # Rabbit constants
 RABBIT_CLIENT_EXCHANGE = 'client_messages'
+RABBIT_CANCEL_TIMEOUT = 5.0

--- a/server/environment.py
+++ b/server/environment.py
@@ -14,6 +14,8 @@ WEB_SERVER_URL = load_env_var('WEB_SERVER_URL', 'localhost')
 WEB_SERVER_PORT = load_env_var('WEB_SERVER_PORT', '8000')
 REDIS_HOST = load_env_var('REDIS_HOST', 'localhost')
 REDIS_LOCAL_PORT = load_env_var('REDIS_LOCAL_PORT', '6379')
+RABBIT_HOST = load_env_var('RABBIT_HOST', 'localhost')
+RABBIT_PORT = load_env_var('RABBIT_PORT', '5672')
 
 # Temporary?
 FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT = load_env_var('QUORIDOR_HOST_PORT', 'localhost:50051')

--- a/server/queues.py
+++ b/server/queues.py
@@ -1,0 +1,48 @@
+import json
+import pika
+from pika.exchange_type import ExchangeType
+
+from server.connection_manager import manager
+
+from server.environment import RABBIT_HOST, RABBIT_PORT
+from server.constants import RABBIT_CLIENT_EXCHANGE
+
+
+class QueueManager:
+
+    def __init__(self):
+        QueueManager.instance = self
+        self.connection = pika.BlockingConnection(pika.ConnectionParameters(RABBIT_HOST, RABBIT_PORT))
+        self.channel = self.connection.channel()
+        self.channel.exchange_declare(RABBIT_CLIENT_EXCHANGE, ExchangeType.direct)
+        self.channel.queue_declare(auto_delete=True)
+        self.channel.queue_bind('', RABBIT_CLIENT_EXCHANGE)
+
+    @staticmethod
+    def get_instance():
+        return getattr(QueueManager, 'instance', QueueManager())
+
+    async def listen(self):
+        self.channel.basic_consume('', QueueManager.message_callback)
+        self.channel.start_consuming()
+
+    @staticmethod
+    def message_callback(ch, method, properties, body):
+        print(body.decode())
+        event, data = body.decode().split('//')
+        data = json.loads(data)
+        manager.send(method.routing_key, event, data)
+        ch.basic_ack(method.delivery_tag)
+
+    def send(self, client, event, data):
+        self.channel.basic_publish(
+            RABBIT_CLIENT_EXCHANGE,
+            client,
+            '//'.join((event, json.dumps(data)))
+        )
+
+    def register_client(self, client):
+        self.channel.queue_bind('', RABBIT_CLIENT_EXCHANGE, client)
+
+    def unregister_client(self, client):
+        self.channel.queue_unbind('', RABBIT_CLIENT_EXCHANGE, client)

--- a/server/queues.py
+++ b/server/queues.py
@@ -17,6 +17,7 @@ class QueueManager:
         self.channel.queue_bind('', RABBIT_CLIENT_EXCHANGE)
         self.listener = None
         self.receiver = None
+        QueueManager.instance = self
 
     def set_message_receiver(self, receiver):
         # TODO: receiver should be an interface implemented by ConnectionManager

--- a/server/server.py
+++ b/server/server.py
@@ -1,6 +1,6 @@
 import starlette
 from fastapi import FastAPI, WebSocket
-from server.connection_manager import manager
+from server.connection_manager import ConnectionManager
 from .router import router
 from server.factory_event_server import FactoryServerEvent
 import json
@@ -11,7 +11,7 @@ app.include_router(router)
 
 @app.websocket("/ws/")
 async def session(websocket: WebSocket, token):
-    client = await manager.connect(websocket, token)
+    client = await ConnectionManager.instance.connect(websocket, token)
     if client is None:
         return
     try:
@@ -23,5 +23,5 @@ async def session(websocket: WebSocket, token):
                 data = {}
             await FactoryServerEvent.get_event(data, client).run()
     except starlette.websockets.WebSocketDisconnect:
-        await manager.remove_user(client)
+        await ConnectionManager.instance.remove_user(client)
         return

--- a/server/websockets.py
+++ b/server/websockets.py
@@ -1,5 +1,5 @@
 import server.constants as websocket_events
-from server.connection_manager import manager
+from server.connection_manager import ConnectionManager
 from typing import Dict, List
 
 
@@ -8,7 +8,7 @@ async def notify_challenge_to_client(
     opponent: str,
     challenge_id: str,
 ):
-    await manager.bulk_send(
+    await ConnectionManager.instance.bulk_send(
         clients,
         websocket_events.EVENT_SEND_CHALLENGE,
         {
@@ -19,7 +19,7 @@ async def notify_challenge_to_client(
 
 
 async def notify_error_to_client(client: str, error: str):
-    await manager.send(
+    await ConnectionManager.instance.send(
         client,
         websocket_events.EVENT_SEND_ERROR,
         {
@@ -29,7 +29,7 @@ async def notify_error_to_client(client: str, error: str):
 
 
 async def notify_your_turn(client: str, data: Dict):
-    await manager.send(
+    await ConnectionManager.instance.send(
         client,
         websocket_events.EVENT_SEND_YOUR_TURN,
         data,
@@ -37,7 +37,7 @@ async def notify_your_turn(client: str, data: Dict):
 
 
 async def notify_user_list_to_client(client: str, users: List[str]):
-    await manager.send(
+    await ConnectionManager.instance.send(
         client,
         websocket_events.EVENT_LIST_USERS,
         {
@@ -48,7 +48,7 @@ async def notify_user_list_to_client(client: str, users: List[str]):
 
 async def notify_end_game_to_client(players: List[str], data: Dict):
     for client in players:
-        await manager.send(
+        await ConnectionManager.instance.send(
             client,
             websocket_events.EVENT_GAME_OVER,
             data,
@@ -56,7 +56,7 @@ async def notify_end_game_to_client(players: List[str], data: Dict):
 
 
 async def notify_feedback(client, feedback):
-    await manager.send(
+    await ConnectionManager.instance.send(
         client,
         websocket_events.EVENT_FEEDBACK,
         feedback,

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -24,6 +24,12 @@ class TestConnectionManager(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.manager = ConnectionManager()
+        self.manager.queue_manager = MagicMock()
+
+    def test_set_queue_manager(self):
+        queue_manager = MagicMock()
+        self.manager.set_queue_manager(queue_manager)
+        self.assertEqual(self.manager.queue_manager, queue_manager)
 
     @parameterized.expand([
         (

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,6 +25,11 @@ class TestQueue(unittest.TestCase):
         self.manager.channel = MagicMock()
         self.manager.receiver = MagicMock()
 
+    def test_set_message_receiver(self):
+        recv = MagicMock()
+        self.manager.set_message_receiver(recv)
+        self.assertEqual(self.manager.receiver, recv)
+
     @patch.object(QueueManager, '_consume', new=MagicMock())
     @patch('asyncio.create_task')
     def test_listen(self, create_task_patched):
@@ -41,6 +46,13 @@ class TestQueue(unittest.TestCase):
         self.manager.listen()
         self.manager.channel.basic_consume.assert_not_called()
         self.assertEqual(self.manager.listener, 1)
+
+    @patch('asyncio.wait_for', new=MagicMock())
+    def test_stop(self):
+        listener = MagicMock()
+        self.manager.listener = listener
+        self.manager.stop()
+        self.assertEqual(self.manager.listener, None)
 
     @patch('asyncio.create_task', new=MagicMock())
     def test_message_callback(self):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -23,16 +23,7 @@ class TestQueue(unittest.TestCase):
     def setUp(self) -> None:
         self.manager = QueueManager()
         self.manager.channel = MagicMock()
-
-    def tearDown(self) -> None:
-        del QueueManager.instance
-
-    @patch('pika.BlockingConnection', new=MagicMock())
-    def test_get_instance(self):
-        del QueueManager.instance
-        instance_1 = QueueManager.get_instance()
-        instance_2 = QueueManager.get_instance()
-        self.assertEqual(instance_1, instance_2)
+        self.manager.receiver = MagicMock()
 
     @patch.object(QueueManager, '_consume', new=MagicMock())
     @patch('asyncio.create_task')
@@ -41,7 +32,7 @@ class TestQueue(unittest.TestCase):
         self.assertIsNotNone(self.manager.listener)
         self.manager.channel.basic_consume.assert_called_with(
             '',
-            QueueManager.message_callback,
+            self.manager.message_callback,
         )
         create_task_patched.assert_called_with(self.manager._consume())
 
@@ -51,16 +42,16 @@ class TestQueue(unittest.TestCase):
         self.manager.channel.basic_consume.assert_not_called()
         self.assertEqual(self.manager.listener, 1)
 
-    @patch('server.queues.manager')
-    def test_message_callback(self, manager_patched):
+    @patch('asyncio.create_task', new=MagicMock())
+    def test_message_callback(self):
         channel = MagicMock()
         method = MagicMock(
             routing_key='some_client',
             delivery_tag=1,
         )
         body = b'list_users//{"users": ["bot1", "bot2", "bot3"]}'
-        QueueManager.message_callback(channel, method, None, body)
-        manager_patched.send.assert_called_with(
+        self.manager.message_callback(channel, method, None, body)
+        self.manager.receiver.send.assert_called_with(
             'some_client',
             'list_users',
             {'users': ['bot1', 'bot2', 'bot3']}

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,3 +1,4 @@
+from server.constants import RABBIT_CLIENT_EXCHANGE
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -67,10 +68,29 @@ class TestQueue(unittest.TestCase):
         channel.basic_ack.assert_called_with(1)
 
     def test_send(self):
-        pass
+        self.manager.send(
+            'some_client',
+            'list_users',
+            {"users": ["bot1", "bot2", "bot3"]}
+        )
+        self.manager.channel.basic_publish.assert_called_with(
+            RABBIT_CLIENT_EXCHANGE,
+            'some_client',
+            'list_users//{"users": ["bot1", "bot2", "bot3"]}',
+        )
 
     def test_register_client(self):
-        pass
+        self.manager.register_client('some_client')
+        self.manager.channel.queue_bind.assert_called_with(
+            '',
+            RABBIT_CLIENT_EXCHANGE,
+            'some_client'
+        )
 
     def test_unregister_client(self):
-        pass
+        self.manager.unregister_client('some_client')
+        self.manager.channel.queue_unbind.assert_called_with(
+            '',
+            RABBIT_CLIENT_EXCHANGE,
+            'some_client'
+        )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from server.queues import QueueManager
+
+
+class TestQueueAsync(unittest.IsolatedAsyncioTestCase):
+
+    @patch('pika.BlockingConnection', new=MagicMock())
+    def setUp(self) -> None:
+        self.manager = QueueManager()
+
+    async def test_consume(self):
+        self.manager.channel = MagicMock()
+        await self.manager._consume()
+        self.manager.channel.start_consuming.assert_called()
+
+
+class TestQueue(unittest.TestCase):
+
+    @patch('pika.BlockingConnection', new=MagicMock())
+    def setUp(self) -> None:
+        self.manager = QueueManager()
+
+    def tearDown(self) -> None:
+        del QueueManager.instance
+
+    @patch('pika.BlockingConnection', new=MagicMock())
+    def test_get_instance(self):
+        del QueueManager.instance
+        instance_1 = QueueManager.get_instance()
+        instance_2 = QueueManager.get_instance()
+        self.assertEqual(instance_1, instance_2)
+
+    def test_listen(self):
+        pass
+
+    def test_message_callback(self):
+        pass
+
+    def test_send(self):
+        pass
+
+    def test_register_client(self):
+        pass
+
+    def test_unregister_client(self):
+        pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,9 @@ class TestServer(unittest.IsolatedAsyncioTestCase):
         websocket = AsyncMock()
         websocket.receive_text.side_effect = starlette.websockets.WebSocketDisconnect()
 
-        with patch('server.server.manager', new_callable=AsyncMock) as manager_patched:
+        with patch('server.server.ConnectionManager.instance') as manager_patched:
+            manager_patched.connect = AsyncMock()
+            manager_patched.remove_user = AsyncMock()
             manager_patched.connect.return_value = 'User 1'
             await server.session(websocket, 'token')
             manager_patched.connect.assert_called_with(websocket, 'token')

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from server.connection_manager import ConnectionManager
 from server.websockets import (
@@ -31,6 +31,7 @@ class TestWebsockets(unittest.IsolatedAsyncioTestCase):
             },
         )
 
+    @patch('server.queues.QueueManager', new=MagicMock())
     @patch.object(ConnectionManager, 'bulk_send', new_callable=AsyncMock)
     async def test_notify_challenge_to_client(self, send_patched):
         challenge_sender = 'User 1'


### PR DESCRIPTION
- Connect to RabbitMQ
- Declare a queue for the instance
- Declare exchange for client messages
- Connect queue to the exchange
- Implement methods:
    - Register client with a routing key in the exchange
    - Unregister client routing key from the exchange
    - Receive messages from the queue
    - Send data from queue to client through websocket
    - Send messages to queue
- Integrate queues:
    - Register/unregister clients in queue on connect/disconnect
    - Send messages to queue if client is not found in dict
    - Send messages from queue to clients