### PR TITLE
[PATCH] Add game_id to gameover response

### DIFF
--- a/server/utilities_server_event.py
+++ b/server/utilities_server_event.py
@@ -143,5 +143,6 @@ class ServerEvent:
     async def game_over(cls, data, game: dict):
         next_turn(data.game_id)
         end_data = make_end_data_for_web(data.turn_data)
+        data.turn_data["game_id"] = data.game_id
         await notify_end_game_to_client(game.get(PLAYERS), data.turn_data)
         await notify_end_game_to_web(data.game_id, game.get(TOURNAMENT_ID), end_data)

--- a/tests/test_utilities_server_event.py
+++ b/tests/test_utilities_server_event.py
@@ -239,7 +239,7 @@ class TestServerEvent(unittest.IsolatedAsyncioTestCase):
             'name': DEFAULT_GAME,
         }
         game_id = 'f34i3f'
-        turn_data = 'test_turn_data'
+        turn_data = {"turn_data": "turn_data"}
         data = MagicMock(
             game_id=game_id,
             turn_data=turn_data,


### PR DESCRIPTION
Now the gameover response has the `game_id` value

`< {"event": "game_over", "data": {"score_2": 0.0, "board": "        N     N                                                                                         N                                                                                                     S                                       S     S                                    ", "score_1": -6.0, "walls": 10.0, "player_2": "brz", "side": "N", "remaining_moves": 0.0, "player_1": "brz", "game_id": "74696b76-d167-11ec-9d00-0242ac120004"}}
`