### PR TITLE
[MINOR][EDA-1657] Change fake discovery game host

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -15,8 +15,9 @@ GAMEIDERROR = 'GAMEID_ERROR'
 REDIS_ERROR = -1
 
 # Game constants
-# DEFAULT_GAME = 'quoridor'
 DEFAULT_GAME = 'wumpus'
+GAME_HOST_PORT = "WUMPUS_HOST_PORT"
+GAME_PORT = "localhost:50052"
 EMPTY_PLAYER = ''
 
 # Time constants

--- a/server/environment.py
+++ b/server/environment.py
@@ -1,5 +1,10 @@
 import os
 
+from server.constants import (
+    GAME_HOST_PORT,
+    GAME_PORT
+)
+
 
 def load_env_var(name: str, default: str = None):
     var = os.environ.get(name, default)
@@ -18,5 +23,4 @@ RABBIT_HOST = load_env_var('RABBIT_HOST', 'localhost')
 RABBIT_PORT = load_env_var('RABBIT_PORT', '5672')
 
 # Temporary?
-# FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT = load_env_var('QUORIDOR_HOST_PORT', 'localhost:50051')
-FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT = load_env_var('WUMPUS_HOST_PORT', 'localhost:50052')
+FAKE_SERVICE_DISCOVERY_GAME_HOST_PORT = load_env_var(GAME_HOST_PORT, GAME_PORT)

--- a/server/grpc_adapter.py
+++ b/server/grpc_adapter.py
@@ -1,13 +1,13 @@
 from edagames_grpc.client import ClientGRPC
 
-from server.environment import FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT
+from server.environment import FAKE_SERVICE_DISCOVERY_GAME_HOST_PORT
 
 
 cached_adapters = {}
 
 
 def discover_game(game_name: str):
-    return FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT.split(':')
+    return FAKE_SERVICE_DISCOVERY_GAME_HOST_PORT.split(':')
 
 
 class GRPCAdapterFactory:


### PR DESCRIPTION
Before that ticket, the form to change "Quoridor" for "Wumpus" in the server was code smelt. So I change 

`FAKE_SERVICE_DISCOVERY_QUORIDOR_HOST_PORT` 

to 

`FAKE_SERVICE_DISCOVERY_GAME_HOST_PORT`

To say more generally that it is variable, it refers to the game not only for quoridor or wumpus 

Also, I created two new constants to refer to the port and environment variable that the server should listen to. 

```
DEFAULT_GAME = 'wumpus'
GAME_HOST_PORT = "WUMPUS_HOST_PORT"
GAME_PORT = "localhost:50052"
```
If you want to change the game only need to change this constant for

```
DEFAULT_GAME = 'quoridor'
GAME_HOST_PORT = "QUORIDOR_HOST_PORT"
GAME_PORT = "localhost:50051"
```

Then with this changes server can play quoridor or wumpus depends of these constants 


