### PR TITLE
fixing issues with boto3 client

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -57,12 +57,13 @@ async def apigw_connect(request: Request):
 
     connection_manager = APIGatewayConnectionManager.instance
     client_id = req_body["client_id"]
+    apigw_url = req_body["apigw_ws_endpoint"]
 
     try:
         # Verify client using request.json()['query']['token']
         parsed_query = req_body['query'].strip('{}').split(', ')
         token = [v for (k, v) in [x.split('=') for x in parsed_query] if k == 'token'][0]
-        await connection_manager.connect(client_id, token)
+        await connection_manager.connect(apigw_url, client_id, token)
     except (json.JSONDecodeError, IndexError, AuthenticationError) as e:
         logger.warning(f'Error authenticating client ({client_id}): {e}')
         # Explicitly disconnect if auth fails using DELETE @connections api


### PR DESCRIPTION
This PR it's a re-iteration of a previous one, in which I wanted to make the server agnostic. It came with a bug because when Django makes a challenge a said to the server notifies the user(bot) implicated in the challenge the server doesn't know which is the API Gateway to send the message.

I refactor this to provide a way to link the Bot(with his client id)  to an `API Gateway URL` and this URL I use to get the correct Boto3 client

All this I made with 2 new dictionaries.
On that have all the boto3 clients linked with the apigw_url of the bot and another one where is linked to the client_id and the apigw_url