### PR TITLE
[EDA-1790][Minor]debug_mode added

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -47,6 +47,7 @@ CLIENT_LIST = 'client'
 
 # dict.get values
 DATA = 'data'
+DEBUG_MODE = 'debug_mode'
 GAME_NAME = 'game'
 PLAYERS = 'players'
 

--- a/server/game.py
+++ b/server/game.py
@@ -21,11 +21,13 @@ def data_challenge(
     players: List[str],
     accepted: List[str],
     name: str,
+    debug_mode: bool,
 ):
     data = {
         'players': players,
         'accepted': accepted,
         'game': name,
+        'debug_mode': debug_mode,
     }
 
     return json.dumps(data)

--- a/server/models.py
+++ b/server/models.py
@@ -8,6 +8,7 @@ class Challenge(BaseModel):
     challenger: str
     challenged: List[str]
     game_name: str = DEFAULT_GAME
+    debug_mode: bool = False
 
 
 class Tournament(BaseModel):

--- a/server/router.py
+++ b/server/router.py
@@ -16,7 +16,8 @@ async def challenge(challenge: Challenge):
         await make_challenge(
             challenge.challenger,
             challenge.challenged,
-            challenge.game_name
+            challenge.game_name,
+            challenge.debug_mode,
         )
         return challenge
     except Exception as e:
@@ -33,7 +34,11 @@ async def challenge(challenge: Challenge):
 @router.post('/tournament')
 async def tournament(tournament: Tournament):
     try:
-        await make_tournament(tournament.tournament_id, tournament.challenges, tournament.game_name)
+        await make_tournament(
+            tournament.tournament_id,
+            tournament.challenges,
+            tournament.game_name,
+        )
     except Exception as e:
         message = f'Unhandled exception ocurred: {e}'
         status = 500

--- a/server/server_event.py
+++ b/server/server_event.py
@@ -7,21 +7,22 @@ from server.redis_interface import (
     redis_get,
 )
 from server.constants import (
+    ABORT_GAME,
+    ACCEPT_CHALLENGE,
+    ASK_CHALLENGE,
+    CHALLENGE_ID,
     CLIENT_LIST,
     CLIENT_LIST_KEY,
-    LIST_USERS,  # name_event
-    ASK_CHALLENGE,
-    ACCEPT_CHALLENGE,
-    MOVEMENTS,
-    ABORT_GAME,
-    CHALLENGE_ID,
-    GAME_ID,
-    MSG_TURN_TOKEN,
-    TURN_TOKEN,
-    OPPONENT,
-    EMPTY_PLAYER,  # game_over
-    GAME_NAME,  # dict.get values
+    DEBUG_MODE,
     DEFAULT_GAME,
+    EMPTY_PLAYER,  # game_over
+    GAME_ID,
+    GAME_NAME,  # dict.get values
+    LIST_USERS,  # name_event
+    MOVEMENTS,
+    MSG_TURN_TOKEN,
+    OPPONENT,
+    TURN_TOKEN,
 )
 
 
@@ -111,7 +112,11 @@ class Movements(ServerEvent):
         if data_received.current_player == EMPTY_PLAYER:
             await self.game_over(data_received, game_data)
         else:
-            await move(data_received, game_data.get(GAME_NAME))
+            await move(
+                data_received,
+                game_data.get(GAME_NAME),
+                game_data.get(DEBUG_MODE),
+            )
 
 
 class AbortGame(ServerEvent):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -4,8 +4,10 @@ from unittest.mock import patch
 from parameterized.parameterized import parameterized
 
 from server.game import data_challenge, identifier, next_turn
-from server.constants import (
-    DEFAULT_GAME,
+from server.constants import DEFAULT_GAME
+from tests.test_scenarios import (
+    DATA_CHALLENGE_SCENARIO_DEBUG_FALSE,
+    DATA_CHALLENGE_SCENARIO_DEBUG_TRUE,
 )
 
 
@@ -32,15 +34,27 @@ class TestGame(unittest.TestCase):
 
     @parameterized.expand([
         (
-            ['Pedro', 'Pablo'],
-            '{"players": ["Pedro", "Pablo"], '
-            f'"accepted": ["Pedro"], "game": "{DEFAULT_GAME}"}}'
+            "debug_false",
+            ["JuanBot", "PedroBot"],
+            ["JuanBot"],
+            False,
+            DATA_CHALLENGE_SCENARIO_DEBUG_TRUE,
         ),
         (
-            ['Pedro', 'Pablo'],
-            f'{{"players": ["Pedro", "Pablo"], "accepted": ["Pedro"], "game": "{DEFAULT_GAME}"}}'
+            "debug_true",
+            ["JuanBot", "PedroBot"],
+            ["JuanBot"],
+            True,
+            DATA_CHALLENGE_SCENARIO_DEBUG_FALSE,
         ),
     ])
-    def test_data_challenge(self, players, expected):
-        res = data_challenge(players, [players[0]], DEFAULT_GAME)
+    def test_data_challenge(
+        self,
+        name,
+        players,
+        accepted,
+        debug_mode,
+        expected,
+    ):
+        res = data_challenge(players, accepted, DEFAULT_GAME, debug_mode)
         self.assertEqual(res, expected)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -26,15 +26,22 @@ class TestRouter(unittest.IsolatedAsyncioTestCase):
         data = {
             "challenger": challenger,
             "challenged": challenged,
+            "debug_mode": False,
         }
         expected = {**data, 'game_name': DEFAULT_GAME}
+        debug_mode = False
         with patch('server.router.make_challenge') as mock_make_challenge:
             async with AsyncClient(app=app, base_url="http://test") as ac:
                 response = await ac.post(
                     "/challenge",
                     json=data
                 )
-        mock_make_challenge.assert_awaited_once_with(challenger, challenged, DEFAULT_GAME)
+        mock_make_challenge.assert_awaited_once_with(
+            challenger,
+            challenged,
+            DEFAULT_GAME,
+            debug_mode,
+        )
         self.assertEqual(response.status_code, status)
         self.assertEqual(response.json(), expected)
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,10 @@
+from server.constants import DEFAULT_GAME
+
+
+DATA_CHALLENGE_SCENARIO_DEBUG_TRUE = (
+    f'{{"players": ["JuanBot", "PedroBot"], "accepted": ["JuanBot"], "game": "{DEFAULT_GAME}", "debug_mode": false}}'
+)
+
+DATA_CHALLENGE_SCENARIO_DEBUG_FALSE = (
+    f'{{"players": ["JuanBot", "PedroBot"], "accepted": ["JuanBot"], "game": "{DEFAULT_GAME}", "debug_mode": true}}'
+)


### PR DESCRIPTION
To be able to receive challenges from the Django app in debug_mode, I had to add this boolean attribute to the Challenge class. By default, this attribute is set as False.
With this, I also had to modify the following function:

- `utilities_server_event.make_challenge() `
- `utilities_server_event.move() `
- `utilities_server_event.make_penalize`
- `game.data_challenge()`

These functions had to be modified so they could accept the new debug_mode parameter.
Now the make_penalize() function receives the debug_mode parameter so, I could modify it to evaluate this parameter to set the TIME_OUT that the function sleeps.