### PR TITLE
[EDA-1797][Minor]Change make penalize

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -21,10 +21,12 @@ GAME_PORT = "localhost:50052"
 EMPTY_PLAYER = ''
 
 # Time constants
+DEBUG_AWAIT = 60
+DEFAULT_EXPIRE = 7200  # default expire of 2hs
+NORMAL_AWAIT = 15
 TIME_SLEEP = 15
 TIME_CHALLENGE = 300
 TOKEN_EXPIRE = TIME_SLEEP + 15
-DEFAULT_EXPIRE = 7200  # default expire of 2hs
 LOG_EXPIRE = 21600  # expire time for logs of 6h
 
 # Factory Event

--- a/server/utilities_server_event.py
+++ b/server/utilities_server_event.py
@@ -43,7 +43,7 @@ from server.web_requests import notify_end_game_to_web
 async def move(
     data,
     game_name: str,
-    debug_mode: bool,
+    debug_mode,
 ):
     token = await make_move(data)
     asyncio.create_task(

--- a/server/utilities_server_event.py
+++ b/server/utilities_server_event.py
@@ -9,12 +9,13 @@ from uvicorn.config import logger
 from server.constants import (
     CHALLENGE_ID,
     DATA,
+    DEBUG_AWAIT,
     DEBUG_MODE,
     EMPTY_PLAYER,
     GAME_ID,
     GAME_NAME,
+    NORMAL_AWAIT,
     PLAYERS,
-    TIME_SLEEP,
     TOKEN_COMPARE,
     TOURNAMENT_ID,
     TURN_TOKEN,
@@ -125,7 +126,8 @@ async def make_penalize(
     past_token,
     debug_mode,
 ):
-    await asyncio.sleep(TIME_SLEEP)
+    PENALIZE_AWAIT = DEBUG_AWAIT if debug_mode else NORMAL_AWAIT
+    await asyncio.sleep(PENALIZE_AWAIT)
     token_valid = await redis_get(
         data.game_id,
         TOKEN_COMPARE,


### PR DESCRIPTION
As the utilities_server_event.make_penalize() function receives the debug_mode parameter of the challenge, and now is able to evaluate this parameter with this, the function now can set up the sleep time that awaits to penalize the player.

The main change to the make_penalize() was adding the evaluation :

`PENALIZE_AWAIT = DEBUG_AWAIT if debug_mode else NORMAL_AWAIT`